### PR TITLE
Re: +Emoji improvement for Double-click information dialog.👩🏻‍🍳 (tkytel/mantela-viewer#19)

### DIFF
--- a/mantela.css
+++ b/mantela.css
@@ -15,3 +15,122 @@
 	position: relative;
 	background-color: rgba(64, 64, 64, 0.1);
 }
+
+/* ダブルクリック時の絵文字用クラス（for nodeName） */
+.mantela-node::before {
+	display: inline-block;
+	content: '';
+	width: 1em; height: 1em;
+	vertical-align: -10%;	/* XXX */
+	background: center / cover no-repeat url('./img/unknown.svg');
+	margin-inline-end: 1em;
+}
+.mantela-node-PBX::before {
+	/* OFFICE BUILDING Emoji */
+	content: '\1F3E2';
+	vertical-align: unset;
+	background: unset;
+}
+.mantela-node-alias::before {
+	background-image: url('./img/alias.svg');
+}
+.mantela-node-application::before {
+	background-image: url('./img/application.svg');
+}
+.mantela-node-cellphone::before {
+	background-image: url('./img/cellphone.svg');
+}
+.mantela-node-conference::before {
+	background-image: url('./img/conference.svg');
+}
+.mantela-node-dialphone::before {
+	background-image: url('./img/dialphone.svg');
+}
+.mantela-node-fax::before {
+	background-image: url('./img/fax.svg');
+}
+.mantela-node-information::before {
+	background-image: url('./img/information.svg');
+}
+.mantela-node-main::before {
+	background-image: url('./img/main.svg');
+}
+.mantela-node-modem::before {
+	background-image: url('./img/modem.svg');
+}
+.mantela-node-music::before {
+	background-image: url('./img/music.svg');
+}
+.mantela-node-other::before {
+	background-image: url('./img/other.svg');
+}
+.mantela-node-phone::before {
+	background-image: url('./img/phone.svg');
+}
+.mantela-node-pushphone::before {
+	background-image: url('./img/pushphone.svg');
+}
+.mantela-node-reserved::before {
+	background-image: url('./img/reserved.svg');
+}
+.mantela-node-smartphone::before {
+	background-image: url('./img/smartphone.svg');
+}
+.mantela-node-switchboard::before {
+	background-image: url('./img/switchboard.svg');
+}
+.mantela-node-unknown::before {
+	background-image: url('./img/unknown.svg');
+}
+.mantela-node-unused::before {
+	background-image: url('./img/unused.svg');
+}
+
+/* ダブルクリック時の絵文字用クラス（for attributes） */
+.mantela-key-extension {
+	/* INPUT NUMBERS Emoji + EM SPACE */
+	list-style: '\1F522\2003';
+}
+.mantela-key-identifier {
+	/* ID Emoji + EM SPACE */
+	list-style: '\1F194\2003';
+}
+.mantela-key-mantela {
+	/* WORLD MAP Emoji + EM SPACE */
+	list-style: '\1F5FA\2003';
+}
+.mantela-key-prefix {
+	/* HASH Emoji with colour, and key cap + EM SPACE */
+	list-style: '\0023\FE0F\20E3\2003';
+}
+.mantela-key-sipServer {
+	/* DESKTOP COMPUTER Emoji with colour + EM SPACE */
+	list-style: '\1F5A5\FE0F\2003';
+}
+.mantela-key-sipUsername {
+	/*
+	 * WOMAN OFFICE WORKER Emoji + EM SPACE;
+	 * WOMAN Emoji with FITZPATRICK TYPE-1–2, ZWJ, and BRIEFCASE Emoji
+	 */
+	list-style: '\1F469\1F3FB\200D\1F4BC\2003';
+}
+.mantela-key-sipPassword {
+	/* KEY Emoji + EM SPACE */
+	list-style: '\1f511\2003';
+}
+.mantela-key-sipPort {
+	/* ELECTRIC PLUG Emoji + EM SPACE */
+	list-style: '\1f50c\2003';
+}
+.mantela-key-preferredPrefix {
+	/* P BUTTON Emoji with colour + EM SPACE */
+	list-style: '\1f17f\FE0F\2003';
+}
+.mantela-key-model {
+	/* WRENCH Emoji with colour + EM SPACE */
+	list-style: '\1f527\2003';
+}
+.mantela-key-transferTo {
+	/* LOUDSPEAKER Emoji + EM SPACE */
+	list-style: '\1f4e2\2003';
+}

--- a/mantela.js
+++ b/mantela.js
@@ -277,6 +277,11 @@ const showNodeInfo = node => new Promise(r => {
 	pre.overflow = 'scroll';
 	pre.append(code);
 
+	const summary = document.createElement('summary');
+	summary.textContent = '全ての情報を表示……';
+	const details = document.createElement('details');
+	details.append(summary, pre);
+
 	// 無視キーリスト ノード情報画面の<ul>リストとして取り扱わないキー
 	const omitKeyList = [
 		'name',		// <h2>として表示
@@ -350,7 +355,7 @@ const showNodeInfo = node => new Promise(r => {
 	}
 
 	const section = document.createElement('section');
-	section.append(nodeName, nodeNames, attributes, pre);
+	section.append(nodeName, nodeNames, attributes, details);
 
 	dialog.append(section, div);
 	dialog.showModal();

--- a/mantela.js
+++ b/mantela.js
@@ -300,7 +300,6 @@ const showNodeInfo = node => new Promise(r => {
 		model: "🔧",
 		transferTo: "📢"
 	}
-	const emoji = document.createElement('div');
 	const nodeName = document.createElement('h2');
 	if (node.type === 'PBX') {
 		// 局のsvgアイコンがないのでビル絵文字で代用
@@ -349,8 +348,11 @@ const showNodeInfo = node => new Promise(r => {
 		attributes.append(item);
 		// TODO リスト表示順がmantela記載順依存で局ごとにバラつくので何とかする🙍🏻‍♀️
 	}
-	emoji.append(nodeName, nodeNames, attributes);
-	dialog.append(emoji, pre, div);
+
+	const section = document.createElement('section');
+	section.append(nodeName, nodeNames, attributes, pre);
+
+	dialog.append(section, div);
 	dialog.showModal();
 });
 

--- a/mantela.js
+++ b/mantela.js
@@ -282,7 +282,7 @@ const showNodeInfo = node => new Promise(r => {
 	const details = document.createElement('details');
 	details.append(summary, pre);
 
-	// 無視キーリスト ノード情報画面の<ul>リストとして取り扱わないキー
+	/* 無視キーリスト ノード情報画面の<ul>リストとして取り扱わないキー */
 	const omitKeyList = [
 		'name',		// <h2>として表示
 		'names',	// <span>として表示
@@ -291,7 +291,8 @@ const showNodeInfo = node => new Promise(r => {
 		'unavailable',	// style=color: silver として処理
 		'geolocationCoordinates'	// TODO FIXME
 	];
-	// 絵文字置換リスト JSONキー→絵文字
+
+	/* 絵文字置換リスト JSONキー→絵文字 */
 	const replaceEmoji = {
 		extension: "🔢",
 		identifier: "🆔",
@@ -307,21 +308,21 @@ const showNodeInfo = node => new Promise(r => {
 	}
 	const nodeName = document.createElement('h2');
 	if (node.type === 'PBX') {
-		// 局のsvgアイコンがないのでビル絵文字で代用
+		/* 局のsvgアイコンがないのでビル絵文字で代用 */
 		nodeName.innerHTML = "🏢";
 	} else {
-		// 端末はsvgアイコンを流用
+		/* 端末はsvgアイコンを流用 */
 		nodeName.innerHTML =
 		'<img style ="height: 3vw; display: inline; margin-right: 1vw" src="img/' + node.type + '.svg"/>';
 	}
-	nodeName.innerHTML += node.name;	// 局名・端末名
+	nodeName.innerHTML += node.name;	/* 局名・端末名 */
 	const nodeNames = document.createElement('span');
 	if (node.names.length >= 2) {
-		// 名前を複数持つ場合のみ names: [] を表示
+		/* 名前を複数持つ場合のみ names: [] を表示 */
 		nodeNames.textContent = "( " + node.names + " )";
 	}
 	if (node.unavailable == 'true') {
-		// unavailable = true な局は文字の色変え
+		/* unavailable = true な局は文字の色変え */
 		const unavailable_color	= 'silver';
 		dialog.style.color	= unavailable_color;
 		nodeName.style.color	= unavailable_color;
@@ -329,29 +330,31 @@ const showNodeInfo = node => new Promise(r => {
 	}
 	const attributes = document.createElement('ul');
 	for(let key in node) {
-		// リストを組み立て
-		let icon = key + " = ";	// 絵文字置換リストにないキーは key = value として表示
+		/* リストを組み立て */
+		let icon = key + " = ";	/* 絵文字置換リストにないキーは key = value として表示 */
 		let item = document.createElement('li');
 		item.style.listStyle = 'none';
 		item.style.paddingLeft = 0;
 		if (omitKeyList.includes(key) || node[key].length === 0) {
-			// 無視リストにあるキーの場合はリストに載せない
-			// Value が空値の場合はリストに載せない
+			/*
+			 * 無視リストにあるキーの場合はリストに載せない
+			 * Value が空値の場合はリストに載せない
+			 */
 			continue;
 		}
 		if (key in replaceEmoji) {
-			// 絵文字置換
+			/* 絵文字置換 */
 			icon = replaceEmoji[key];
 		}
 		if (key === 'mantela') {
-			// mantela: の場合はリンク化
+			/* mantela: の場合はリンク化 */
 			item.innerHTML = icon + '<a href="' + node[key] + '">' + node[key] + '</a>';
 		} else {
-			// それ以外はそのままリスト表示
+			/* それ以外はそのままリスト表示 */
 			item.innerHTML = icon + node[key];
 		}
 		attributes.append(item);
-		// TODO リスト表示順がmantela記載順依存で局ごとにバラつくので何とかする🙍🏻‍♀️
+		/* TODO リスト表示順がmantela記載順依存で局ごとにバラつくので何とかする🙍🏻‍♀️ */
 	}
 
 	const section = document.createElement('section');

--- a/mantela.js
+++ b/mantela.js
@@ -278,7 +278,7 @@ const showNodeInfo = node => new Promise(r => {
 	pre.append(code);
 
 	// 無視キーリスト ノード情報画面の<ul>リストとして取り扱わないキー
-	const omit_key_list = [
+	const omitKeyList = [
 		'name',		// <h2>として表示
 		'names',	// <span>として表示
 		'type',		// <img>として表示
@@ -287,7 +287,7 @@ const showNodeInfo = node => new Promise(r => {
 		'geolocationCoordinates'	// TODO FIXME
 	];
 	// 絵文字置換リスト JSONキー→絵文字
-	const replace_emoji = {
+	const replaceEmoji = {
 		extension: "🔢",
 		identifier: "🆔",
 		mantela: "🗺️",
@@ -301,26 +301,26 @@ const showNodeInfo = node => new Promise(r => {
 		transferTo: "📢"
 	}
 	const emoji = document.createElement('div');
-	const node_name = document.createElement('h2');
+	const nodeName = document.createElement('h2');
 	if (node.type === 'PBX') {
 		// 局のsvgアイコンがないのでビル絵文字で代用
-		node_name.innerHTML = "🏢";
+		nodeName.innerHTML = "🏢";
 	} else {
 		// 端末はsvgアイコンを流用
-		node_name.innerHTML =
+		nodeName.innerHTML =
 		'<img style ="height: 3vw; display: inline; margin-right: 1vw" src="img/' + node.type + '.svg"/>';
 	}
-	node_name.innerHTML += node.name;	// 局名・端末名
-	const node_names = document.createElement('span');
+	nodeName.innerHTML += node.name;	// 局名・端末名
+	const nodeNames = document.createElement('span');
 	if (node.names.length >= 2) {
 		// 名前を複数持つ場合のみ names: [] を表示
-		node_names.textContent = "( " + node.names + " )";
+		nodeNames.textContent = "( " + node.names + " )";
 	}
 	if (node.unavailable == 'true') {
 		// unavailable = true な局は文字の色変え
 		const unavailable_color	= 'silver';
 		dialog.style.color	= unavailable_color;
-		node_name.style.color	= unavailable_color;
+		nodeName.style.color	= unavailable_color;
 		code.style.color	= unavailable_color;
 	}
 	const attributes = document.createElement('ul');
@@ -330,14 +330,14 @@ const showNodeInfo = node => new Promise(r => {
 		let item = document.createElement('li');
 		item.style.listStyle = 'none';
 		item.style.paddingLeft = 0;
-		if (omit_key_list.includes(key) || node[key].length === 0) {
+		if (omitKeyList.includes(key) || node[key].length === 0) {
 			// 無視リストにあるキーの場合はリストに載せない
 			// Value が空値の場合はリストに載せない
 			continue;
 		}
-		if (key in replace_emoji) {
+		if (key in replaceEmoji) {
 			// 絵文字置換
-			icon = replace_emoji[key];
+			icon = replaceEmoji[key];
 		}
 		if (key === 'mantela') {
 			// mantela: の場合はリンク化
@@ -349,7 +349,7 @@ const showNodeInfo = node => new Promise(r => {
 		attributes.append(item);
 		// TODO リスト表示順がmantela記載順依存で局ごとにバラつくので何とかする🙍🏻‍♀️
 	}
-	emoji.append(node_name, node_names, attributes);
+	emoji.append(nodeName, nodeNames, attributes);
 	dialog.append(emoji, pre, div);
 	dialog.showModal();
 });


### PR DESCRIPTION
tkytel/mantela-viewer#19 に関連して、以下の点を修正しています:

- いくつかの脆弱なコードについて、適切にエスケープするなどして対策しています。
- 些細で個人的な修正: 変数名などをキャメルケースにしています。 これは、多くの JavaScript の関数などがそのようであるからです。
- 些細で個人的な修正: コメントの形式を /* */ の形式にしています。 これは、将来 JavaScipt のソースコードが minify されるときに事故の発生するおそれをわずかに低減します。
- ダイアローグの DOM ヒエラルキの修正: section タグを利用し、意味的な分類があることを示唆します。
- JSON 本体をデフォルトで非表示: 絵文字を添えられた素敵なリストによって、人間にとって十分な情報を得られますから、素っ裸でつまらない JSON をデフォルトで非表示にします。 ユーザは必要に応じてこれを表示できます。
- 意味のある情報と意味のない情報とを分類し、適切な表示になるようにリファクタリングを行いました。 具体的には:
    - 絵文字のほとんどは CSS によって描画されます。 これらは本質的な情報を提供しないからです。
    - リストは mantela.json のキーの順番によらず、常に同じ順番で表示されます。 これにより、ユーザは必要な情報を迅速に得られるようになります。